### PR TITLE
Fix saving the refresh token 

### DIFF
--- a/build/services/cli/fileGenerators.js
+++ b/build/services/cli/fileGenerators.js
@@ -82,7 +82,7 @@ async function generateConfigFile(container, args, storage) {
     info('Acquiring refresh token...');
     const refreshToken = await getRefreshToken(container, spreadsheetAuthData);
     info('Saving token...');
-    storage.set('refresh_token', refreshToken);
+    storage.set('babelsheet_refresh_token', refreshToken);
     info('Refresh token saved');
 }
 exports.generateConfigFile = generateConfigFile;

--- a/src/services/cli/fileGenerators.spec.ts
+++ b/src/services/cli/fileGenerators.spec.ts
@@ -68,6 +68,6 @@ describe('fileGenerators', async () => {
 
     await generateConfigFile(container, args, inEnvStorage);
 
-    expect(mockInEnvStorage.set).toBeCalledWith('refresh_token', 'test-token');
+    expect(mockInEnvStorage.set).toBeCalledWith('babelsheet_refresh_token', 'test-token');
   });
 });

--- a/src/services/cli/fileGenerators.ts
+++ b/src/services/cli/fileGenerators.ts
@@ -133,6 +133,6 @@ export async function generateConfigFile(container: AwilixContainer, args: Argum
   const refreshToken = await getRefreshToken(container, spreadsheetAuthData);
 
   info('Saving token...');
-  storage.set('refresh_token', refreshToken);
+  storage.set('babelsheet_refresh_token', refreshToken);
   info('Refresh token saved');
 }


### PR DESCRIPTION
Key name was changed, and not updated in source.

Changes:

- key name for the refresh token in the file generator

 