### PR TITLE
Add enum options to the CLI help

### DIFF
--- a/build/services/cli/index.js
+++ b/build/services/cli/index.js
@@ -21,10 +21,10 @@ function configureCli() {
     return yargs
         .usage('Usage: generate [-f "format"] [-n "filename"] [-p "path"]')
         .command('init', 'Generates config file with token for google auth')
-        .option('cf', { alias: 'config-format', default: 'env', describe: 'Config format type', type: 'string' })
+        .option('cf', { alias: 'config-format', default: 'env', describe: 'Config format type', type: 'string', choices: ['env', 'json'] })
         .command('generate', 'Generate file with translations')
         .required(1, 'generate')
-        .option('f', { alias: 'format', default: 'json', describe: 'Format type', type: 'string' })
+        .option('f', { alias: 'format', default: 'json', describe: 'Format type', type: 'string', choices: ['android', 'json', 'ios', 'yml', 'xlf'] })
         .option('p', { alias: 'path', default: '.', describe: 'Path for saving file', type: 'string' })
         .option('l', {
         alias: 'language',

--- a/src/services/cli/index.ts
+++ b/src/services/cli/index.ts
@@ -29,10 +29,10 @@ function configureCli(): Arguments {
   return yargs
     .usage('Usage: generate [-f "format"] [-n "filename"] [-p "path"]')
     .command('init', 'Generates config file with token for google auth')
-    .option('cf', { alias: 'config-format', default: 'env', describe: 'Config format type', type: 'string' })
+    .option('cf', { alias: 'config-format', default: 'env', describe: 'Config format type', type: 'string', choices: ['env','json'] })
     .command('generate', 'Generate file with translations')
     .required(1, 'generate')
-    .option('f', { alias: 'format', default: 'json', describe: 'Format type', type: 'string' })
+    .option('f', { alias: 'format', default: 'json', describe: 'Format type', type: 'string', choices: ['android','json','ios','yml','xlf'] })
     .option('p', { alias: 'path', default: '.', describe: 'Path for saving file', type: 'string' })
     .option('l', {
       alias: 'language',


### PR DESCRIPTION
Add enumerable options list to the CLI help, using yargs "choices" parameter